### PR TITLE
Gradle 7+ sync hatası

### DIFF
--- a/src/android/gradle/amr.gradle
+++ b/src/android/gradle/amr.gradle
@@ -1,8 +1,8 @@
 repositories {
     google()
     jcenter()
-    maven { url 'http://repo.admost.com:8081/artifactory/amr' }
-    maven { url 'http://developer.huawei.com/repo/' }
+    maven { url 'http://repo.admost.com:8081/artifactory/amr'; allowInsecureProtocol = true }
+    maven { url 'http://developer.huawei.com/repo/'; allowInsecureProtocol = true }
     maven { url 'https://verve.jfrog.io/artifactory/verve-gradle-release' }
     maven { url 'https://jitpack.io' }
     


### PR DESCRIPTION
Url ler http olduğundan gradle 7+ sürümlerde sync işlemi yapılamıyor .
Http protokollerine izin verildi .