### PR TITLE
Gradle 7+ sync fix

### DIFF
--- a/src/android/gradle/amr.gradle
+++ b/src/android/gradle/amr.gradle
@@ -1,8 +1,8 @@
 repositories {
     google()
     jcenter()
-    maven { url 'http://repo.admost.com:8081/artifactory/amr' }
-    maven { url 'http://developer.huawei.com/repo/' }
+    maven { url 'http://repo.admost.com:8081/artifactory/amr'; allowInsecureProtocol = true }
+    maven { url 'http://developer.huawei.com/repo/'; allowInsecureProtocol = true }
     maven { url 'https://verve.jfrog.io/artifactory/verve-gradle-release' }
     maven { url 'https://jitpack.io' }
     


### PR DESCRIPTION
Http adresleri gradle 7+ da insecure olduğu için dosyaları çekemiyor .
İnsecure adreslere erişimi açtım